### PR TITLE
[HPB-130] [BE] 制定資料庫架構

### DIFF
--- a/docs/DB.md
+++ b/docs/DB.md
@@ -1,3 +1,32 @@
-## 目前規劃
+```dbml
+// HPB-Blog 資料庫結構
 
-[LINK](https://dbdiagram.io/d/HPB-Blog-68bcd46961a46d388eca4912)
+Table users {
+  id integer [primary key, increment]
+  username varchar(255) [not null, unique]
+  password varchar(255) [not null, note: 'Hashed password']
+  remember_token varchar(100) [null]
+  created_at timestamp [default: `CURRENT_TIMESTAMP`]
+  updated_at timestamp [default: `CURRENT_TIMESTAMP`]
+  deleted_at timestamp [null, note: 'Soft delete']
+
+  Note: 'User accounts and basic activity tracking'
+}
+
+Table posts {
+  id integer [primary key, increment]
+  user_id integer [not null]
+  title varchar(255) [not null]
+  slug varchar(255) [not null, unique, note: 'SEO-friendly URL']
+  content text [not null, note: 'Markdown content']
+  published_at timestamp [null]
+  created_at timestamp [default: `CURRENT_TIMESTAMP`]
+  updated_at timestamp [default: `CURRENT_TIMESTAMP`]
+  deleted_at timestamp [null, note: 'Soft delete']
+
+  Note: 'Blog posts with Markdown support'
+}
+
+// 關聯關係定義
+Ref user_posts: posts.user_id > users.id [delete: cascade]
+```

--- a/docs/DB.md
+++ b/docs/DB.md
@@ -1,0 +1,3 @@
+## 目前規劃
+
+[LINK](https://dbdiagram.io/d/HPB-Blog-68bcd46961a46d388eca4912)

--- a/docs/DB.md
+++ b/docs/DB.md
@@ -5,7 +5,6 @@ Table users {
   id integer [primary key, increment]
   username varchar(255) [not null, unique]
   password varchar(255) [not null, note: 'Hashed password']
-  remember_token varchar(100) [null]
   created_at timestamp [default: `CURRENT_TIMESTAMP`]
   updated_at timestamp [default: `CURRENT_TIMESTAMP`]
   deleted_at timestamp [null, note: 'Soft delete']


### PR DESCRIPTION
[Notion Link](https://www.notion.so/jyu1999/1fccba948f11801b8f64c9d3552e6314?v=1fccba948f1180a4bfc7000cccb396cb&p=260cba948f11808e9504ff095d1f893e&pm=s)

根據 PRD，制定適當的資料庫架構

- HPB-blog 1.0資料表
    
   <img width="1103" height="635" alt="image" src="https://github.com/user-attachments/assets/ace5a479-6b36-4eea-b6f2-3150e88c8720" />
    

## 目前規劃

<img width="1003" height="471" alt="image" src="https://github.com/user-attachments/assets/a2ec5460-da28-4aa4-a492-b3f40e871be3" />


### **移除的表格**

1. **job_batches** - 完全移除
2. **jobs** - 完全移除
3. **failed_jobs** - 完全移除
4. cache - 完全移除
5. session - 完全移除

<aside>
💡說明：

- 目前想不到這專案會把queue用在哪邊先移除 **job_batches** , **jobs** ,**failed_jobs**
- 還處在MVP開發階段，所以先專注在開發登入登出、BLOG 基礎操作的開發上，Cache、Session等到MPV階段結束後再去看需要優化哪些部分適度加上即可
但。
- 目前有看到缺點可能會是登入部分後期會需要調整，先在 user 表中使用`remember_token`  ，一定程度也是要預防後續調整登入這塊需要重構，或是可以使用 JWT 來處理登入問題，如何選擇等團隊討論後在決定
</aside>

---

**users 表格變更 (必要)：**

1. 刪除：`email`  
2. 刪除：`email_verified_at`
3. 刪除：`role`

<aside>
💡說明：

- 刪除`email`  、`email_verified_at` ，目前帳號申請會是以帳號密碼方式
- 目前MVP只會有作者一角色，故刪除 role 欄位
</aside>

---

**posts 表格變更 (必要)：**

1. 保留：id, user_id, title, content, created_at, updated_at, deleted_at
2. 新增：`published_at`
3. 新增：`deleted_at`  
4. 刪除：`status` 

<aside>
💡說明：

- `published_at` PRD 的 FR1 & FR3
- `deleted_at`  若文章發現有問題時可以先進行軟刪除處理
- PRD規劃時有說明不會針對文章狀態進行處理，故刪除 `status`  欄位
</aside>